### PR TITLE
split key Makefile tasks into Makefile.coq.local and delegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@
 .coq-native/
 *.d
 *.vo
+*.vio
+*.vok
+*.vos
 *.glob
 /Makefile.coq
 /extract
 /Makefile.bak
 /Makefile.coq.conf
+.lia.cache

--- a/Makefile
+++ b/Makefile
@@ -8,59 +8,23 @@ MISSING  =								\
 		      egrep -v 'Definition undefined'             |	\
 		      egrep -v '(old|new|research)/'
 
-
 all: Makefile.coq
 	@+$(MAKE) -f Makefile.coq all
 	-@$(MISSING) || exit 0
 
-Makefile.coq: _CoqProject
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
-
-install: Makefile.coq
-	@+$(MAKE) -f Makefile.coq install
-
 clean: Makefile.coq
 	@+$(MAKE) -f Makefile.coq clean
-	rm -fr Setup extract dist .coq-native
-	rm -fr .hdevtools.sock *.glob *.d *.vo
 
-fullclean: clean
+fullclean: Makefile.coq
 	@+$(MAKE) -f Makefile.coq cleanall
-	rm -f Makefile.coq Makefile.coq.conf .Makefile.d
+	rm -f Makefile.coq Makefile.coq.conf
+
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
 force _CoqProject Makefile: ;
 
 %: Makefile.coq force
 	@+$(MAKE) -f Makefile.coq $@
 
-.PHONY: all clean force
-
-
-extraction: src/Extract.vo
-	@if [ ! -d extract ]; then rm -fr extract; fi
-	@if [ ! -d extract ]; then mkdir -p extract/Hask; fi
-	@ls -1 *.hs | egrep -v '(Setup|Hask).hs' |		\
-	    while read file; do					\
-              if ! grep "module Hask" $$file; then		\
-	        perl -i fixcode.pl $$file;			\
-              fi;						\
-	      if [ "$$file" = "eqtype.hs" ]; then		\
-                mv eqtype.hs extract/Hask/Eqtype.hs;		\
-	      elif [ "$$file" = "choice.hs" ]; then		\
-                mv choice.hs extract/Hask/Choice.hs;		\
-	      elif [ "$$file" = "fintype.hs" ]; then		\
-                mv fintype.hs extract/Hask/Fintype.hs;		\
-	      elif [ "$$file" = "seq.hs" ]; then		\
-                mv seq.hs extract/Hask/Seq.hs;			\
-	      elif [ "$$file" = "ssrbool.hs" ]; then		\
-                mv ssrbool.hs extract/Hask/Ssrbool.hs;		\
-	      elif [ "$$file" = "ssreflect.hs" ]; then		\
-                mv ssreflect.hs extract/Hask/Ssreflect.hs;	\
-	      elif [ "$$file" = "ssrfun.hs" ]; then		\
-                mv ssrfun.hs extract/Hask/Ssrfun.hs;		\
-	      elif [ "$$file" = "ssrnat.hs" ]; then		\
-                mv ssrnat.hs extract/Hask/Ssrnat.hs;		\
-              else						\
-                mv $$file extract/Hask;				\
-	      fi						\
-            done
+.PHONY: all clean fullclean force

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,0 +1,33 @@
+extraction: src/Extract.vo
+	@if [ ! -d extract ]; then rm -fr extract; fi
+	@if [ ! -d extract ]; then mkdir -p extract/Hask; fi
+	@ls -1 *.hs | egrep -v '(Setup|Hask).hs' |		\
+	    while read file; do					\
+              if ! grep "module Hask" $$file; then		\
+	        perl -i fixcode.pl $$file;			\
+              fi;						\
+	      if [ "$$file" = "eqtype.hs" ]; then		\
+                mv eqtype.hs extract/Hask/Eqtype.hs;		\
+	      elif [ "$$file" = "choice.hs" ]; then		\
+                mv choice.hs extract/Hask/Choice.hs;		\
+	      elif [ "$$file" = "fintype.hs" ]; then		\
+                mv fintype.hs extract/Hask/Fintype.hs;		\
+	      elif [ "$$file" = "seq.hs" ]; then		\
+                mv seq.hs extract/Hask/Seq.hs;			\
+	      elif [ "$$file" = "ssrbool.hs" ]; then		\
+                mv ssrbool.hs extract/Hask/Ssrbool.hs;		\
+	      elif [ "$$file" = "ssreflect.hs" ]; then		\
+                mv ssreflect.hs extract/Hask/Ssreflect.hs;	\
+	      elif [ "$$file" = "ssrfun.hs" ]; then		\
+                mv ssrfun.hs extract/Hask/Ssrfun.hs;		\
+	      elif [ "$$file" = "ssrnat.hs" ]; then		\
+                mv ssrnat.hs extract/Hask/Ssrnat.hs;		\
+              else						\
+                mv $$file extract/Hask;				\
+	      fi						\
+            done
+.PHONY: extraction
+
+clean::
+	rm -fr Setup extract dist .coq-native
+	rm -fr .hdevtools.sock


### PR DESCRIPTION
Unfortunately, the changes in https://github.com/jwiegley/coq-haskell/commit/a8b31dfd617d8ef44cfd7bbe179104542cf7cafa are not likely to solve the parallelism problems.

Here is my suggested solution, which should still preserve `make extraction`, but hook it in to the dependency analysis done by coq_makefile and allow full parallelism.